### PR TITLE
fix(schedule): 양방향 연관관계 삭제 및 count 조회 로직 추가

### DIFF
--- a/src/main/java/com/example/jpaschedule/domain/controller/ScheduleController.java
+++ b/src/main/java/com/example/jpaschedule/domain/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.example.jpaschedule.domain.controller;
 
 import com.example.jpaschedule.domain.dto.request.ScheduleRequestDto;
+import com.example.jpaschedule.domain.dto.response.SchedulePageResponseDto;
 import com.example.jpaschedule.domain.dto.response.ScheduleResponseDto;
 import com.example.jpaschedule.domain.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,7 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<ScheduleResponseDto>> findAll(@RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size, @RequestBody ScheduleRequestDto dto) {
+    public ResponseEntity<Page<SchedulePageResponseDto>> findAll(@RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size, @RequestBody ScheduleRequestDto dto) {
         return ResponseEntity.ok(scheduleService.findAll(page, size, dto));
     }
 

--- a/src/main/java/com/example/jpaschedule/domain/dto/ReplyCountDto.java
+++ b/src/main/java/com/example/jpaschedule/domain/dto/ReplyCountDto.java
@@ -1,0 +1,14 @@
+package com.example.jpaschedule.domain.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReplyCountDto {
+    private final Long scheduleId;
+    private final Long count;
+
+    public ReplyCountDto(Long scheduleId, Long count) {
+        this.scheduleId = scheduleId;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/example/jpaschedule/domain/dto/response/SchedulePageResponseDto.java
+++ b/src/main/java/com/example/jpaschedule/domain/dto/response/SchedulePageResponseDto.java
@@ -7,34 +7,24 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-public class ScheduleResponseDto {
-
+public class SchedulePageResponseDto {
     private final Long id;
     private final String username;
     private final String title;
     private final String contents;
+    private final Integer replyCount;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime updatedAt;
 
-
-    private ScheduleResponseDto(Long id, String username, String title, String contents, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public SchedulePageResponseDto(Long id, String username, String title, String contents, Integer replyCount, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.username = username;
         this.title = title;
         this.contents = contents;
+        this.replyCount = replyCount;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
-
-    public static ScheduleResponseDto fromSchedule(Schedule schedule) {
-        return new ScheduleResponseDto(schedule.getId(),
-                schedule.getMember().getUsername(),
-                schedule.getTitle(),
-                schedule.getContents(),
-                schedule.getCreatedAt(),
-                schedule.getUpdatedAt());
-    }
-
 }

--- a/src/main/java/com/example/jpaschedule/domain/entity/Schedule.java
+++ b/src/main/java/com/example/jpaschedule/domain/entity/Schedule.java
@@ -27,9 +27,6 @@ public class Schedule extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "schedule", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Reply> replies = new ArrayList<>();
-
     public Schedule() {
     }
 

--- a/src/main/java/com/example/jpaschedule/domain/repository/ReplyRepository.java
+++ b/src/main/java/com/example/jpaschedule/domain/repository/ReplyRepository.java
@@ -1,10 +1,18 @@
 package com.example.jpaschedule.domain.repository;
 
+import com.example.jpaschedule.domain.dto.ReplyCountDto;
 import com.example.jpaschedule.domain.entity.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
     List<Reply> findAllBySchedule_Id(Long scheduleId);
+
+    @Query("SELECT new com.example.jpaschedule.domain.dto.ReplyCountDto(r.schedule.id, count(r)) " +
+            "FROM Reply r " +
+            "WHERE r.schedule.id in :scheduleIds " +
+            "GROUP BY r.schedule.id")
+    List<ReplyCountDto> countByScheduleIds(List<Long> scheduleIds);
 }

--- a/src/main/java/com/example/jpaschedule/domain/service/ScheduleService.java
+++ b/src/main/java/com/example/jpaschedule/domain/service/ScheduleService.java
@@ -2,10 +2,13 @@ package com.example.jpaschedule.domain.service;
 
 import com.example.jpaschedule.common.util.EmptyTool;
 import com.example.jpaschedule.config.context.MemberContext;
+import com.example.jpaschedule.domain.dto.ReplyCountDto;
 import com.example.jpaschedule.domain.dto.request.ScheduleRequestDto;
+import com.example.jpaschedule.domain.dto.response.SchedulePageResponseDto;
 import com.example.jpaschedule.domain.dto.response.ScheduleResponseDto;
 import com.example.jpaschedule.domain.entity.Member;
 import com.example.jpaschedule.domain.entity.Schedule;
+import com.example.jpaschedule.domain.repository.ReplyRepository;
 import com.example.jpaschedule.domain.repository.ScheduleRepository;
 import com.example.jpaschedule.domain.repository.ScheduleRepositoryCustom;
 import com.example.jpaschedule.exception.CustomException;
@@ -18,11 +21,16 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ScheduleService {
 
     private final MemberService memberService;
+    private final ReplyRepository replyRepository;
     private final ScheduleRepository scheduleRepository;
     private final ScheduleRepositoryCustom scheduleRepositoryCustom;
 
@@ -34,10 +42,26 @@ public class ScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ScheduleResponseDto> findAll(int page, int size, ScheduleRequestDto dto) {
+    public Page<SchedulePageResponseDto> findAll(int page, int size, ScheduleRequestDto dto) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("updatedAt").descending());
         Page<Schedule> schedules = scheduleRepositoryCustom.findDynamicSchedules(dto, pageable);
-        return schedules.map(ScheduleResponseDto::fromSchedule);
+        // 과제 해설 세션 이후 양방향 연관관계 삭제 및 count 조회 로직 추가
+        // 일정 ID 리스트
+        List<Long> scheduleIds = schedules.stream().map(Schedule::getId).toList();
+        // 일정 ID 별 댓글 count 조회
+        List<ReplyCountDto> countResults = replyRepository.countByScheduleIds(scheduleIds);
+        // 일정 ID, 댓글 count 맵
+        Map<Long, Long> replyCountMap = countResults.stream().collect(Collectors.toMap(ReplyCountDto::getScheduleId, ReplyCountDto::getCount));
+        // Schedule -> SchedulePageResponseDto convert
+        return schedules.map(schedule -> new SchedulePageResponseDto(
+                schedule.getId(),
+                schedule.getMember().getUsername(),
+                schedule.getTitle(),
+                schedule.getContents(),
+                replyCountMap.getOrDefault(schedule.getId(), 0L).intValue(),
+                schedule.getCreatedAt(),
+                schedule.getUpdatedAt()
+        ));
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
fix(schedule): 과제 해설 세션 후 코드 개선
- 기존 코드 `@oneToMany` 양방향 연관관계 삭제
- 댓글 count용 dto, schedule Page Response 객체
- 댓글 count 로직 추가